### PR TITLE
Fix: space on tags in compressor replace bytes

### DIFF
--- a/FFXIII-ZTR-Decompressor/GameEncoding.cs
+++ b/FFXIII-ZTR-Decompressor/GameEncoding.cs
@@ -240,6 +240,9 @@ namespace FFXIII_ZTR_Decompressor
             {"{VarF4 68}", new byte[] { 0xF4, 0x44 }},
             {"{VarF4 70}", new byte[] { 0xF4, 0x46 }},
             {"{VarF4 72}", new byte[] { 0xF4, 0x48 }},
+            {"{VarF2 79}", new byte[] { 0xF2, 0x4F }},
+            {"{VarF2 82}", new byte[] { 0xF2, 0x52 }},
+            {"{VarF2 87}", new byte[] { 0xF2, 0x57 }},
             {"{VarF2 90}", new byte[] { 0xF2, 0x5A }},
             {"{VarF2 97}", new byte[] { 0xF2, 0x61 }},
             {"{VarF2 100}", new byte[] { 0xF2, 0x64 }},
@@ -268,6 +271,13 @@ namespace FFXIII_ZTR_Decompressor
             {"{VarF7 66}", new byte[] { 0xF7, 0x42 }},
             {"{Var82 152}", new byte[] { 0x82, 0x98 }},
             {"{Var83 182}", new byte[] { 0x83, 0xB6 }},
+            {"{Var87 64}", new byte[] { 0x87, 0x40 }},
+            {"{Var87 65}", new byte[] { 0x87, 0x41 }},
+            {"{Var87 66}", new byte[] { 0x87, 0x42 }},
+            {"{Var87 67}", new byte[] { 0x87, 0x43 }},
+            {"{Var87 68}", new byte[] { 0x87, 0x44 }},
+            {"{Var87 69}", new byte[] { 0x87, 0x45 }},
+            {"{Var87 70}", new byte[] { 0x87, 0x46 }},
 
             #region Icons
             {"{Icon Clock}", new byte[] { 0xF0, 0x40 }},

--- a/FFXIII-ZTR-Decompressor/GameEncoding.cs
+++ b/FFXIII-ZTR-Decompressor/GameEncoding.cs
@@ -37,6 +37,7 @@ namespace FFXIII_ZTR_Decompressor
         public static Dictionary<string, byte[]> JapaneseSymbol = new Dictionary<string, byte[]>
         {
             #region SHIFT JIS Symbols
+            {"{Unknown}", new byte[] { 0x81, 0x40 } }, //resident/system $pause_05a
             {"、", new byte[] { 0x81, 0x41 } },
             {"。", new byte[] { 0x81, 0x42 } },
             {"･", new byte[] { 0x81, 0x45 }},
@@ -161,7 +162,8 @@ namespace FFXIII_ZTR_Decompressor
             {"Ô", new byte[] { 0x85, 0x94 }},
             {"Õ", new byte[] { 0x85, 0x95 }},
             {"Ö", new byte[] { 0x85, 0x96 }},
-            {"×", new byte[] { 0x85, 0x97 }},
+            //{"×", new byte[] { 0x85, 0x97 }},
+            {"×", new byte[] { 0x85, 0xB6 }},
             {"Ø", new byte[] { 0x85, 0x98 }},
             {"Ù", new byte[] { 0x85, 0x99 }},
             {"Ú", new byte[] { 0x85, 0x9A }},

--- a/FFXIII-ZTR-Decompressor/GameEncoding.cs
+++ b/FFXIII-ZTR-Decompressor/GameEncoding.cs
@@ -7,26 +7,34 @@ namespace FFXIII_ZTR_Decompressor
 {
     public static class GameEncoding
     {
-        public static Dictionary<string, int> _EncodingCode = new Dictionary<string, int>
+        public static Dictionary<string, int> EncodingCode = new Dictionary<string, int>
         {
             { "_jp", 932 }, //Japanese (Shift-JIS)
             { "_kr", 51949 }, //Korean (EUC)
             { "_ch", 950 }, //Chinese Traditional (Big5)	
         };
-        private static readonly string[] _LatinCharacters = new string[]
+
+        public static string[] LatinCharacters { get; } = new string[]
         {
             " ", "!", "\"", "#", "$", "%", "&", "'", "(", ")", "*", "+", ",", "-", ".", "/",
             "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ":", ";", "<", "=", ">", "?", "@",
-            "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+            "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U",
+            "V", "W", "X", "Y", "Z",
             "[", "\\", "]", "^", "_", "`",
-            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-            "{", "|", "}", "~", null, "€", null, "‚", null, "„", "…", "†", "‡", null, "‰", "Š", "‹", "Œ", null, "Ž", null, null, "‘", "’", "“", "”", "•",
-            "–", "—", null, "™", "š", "›", "œ", null, "ž", "Ÿ", null, "¡", "¢", "£", "¤", "¥", "¦", "§", "¨", "©", "ª", "«", "¬", null, "®", "¯", "°", "±",
-            "²", "³", "´", "µ", "¶", "·", "¸", "¹", "º", "»", "¼", "½", "¾", "¿", "À", "Á", "Â", "Ã", "Ä", "Å", "Æ", "Ç", "È", "É", "Ê", "Ë", "Ì", "Í",
-            "Î", "Ï", "Ð", "Ñ", "Ò", "Ó", "Ô", "Õ", "Ö", "×", "Ø", "Ù", "Ú", "Û", "Ü", "Ý", "Þ", "ß", "à", "á", "â", "ã", "ä", "å", "æ", "ç", "è", "é",
+            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u",
+            "v", "w", "x", "y", "z",
+            "{", "|", "}", "~", null, "€", null, "‚", null, "„", "…", "†", "‡", null, "‰", "Š", "‹", "Œ", null, "Ž",
+            null, null, "‘", "’", "“", "”", "•",
+            "–", "—", null, "™", "š", "›", "œ", null, "ž", "Ÿ", null, "¡", "¢", "£", "¤", "¥", "¦", "§", "¨", "©", "ª",
+            "«", "¬", null, "®", "¯", "°", "±",
+            "²", "³", "´", "µ", "¶", "·", "¸", "¹", "º", "»", "¼", "½", "¾", "¿", "À", "Á", "Â", "Ã", "Ä", "Å", "Æ",
+            "Ç", "È", "É", "Ê", "Ë", "Ì", "Í",
+            "Î", "Ï", "Ð", "Ñ", "Ò", "Ó", "Ô", "Õ", "Ö", "×", "Ø", "Ù", "Ú", "Û", "Ü", "Ý", "Þ", "ß", "à", "á", "â",
+            "ã", "ä", "å", "æ", "ç", "è", "é",
             "ê", "ë", "ì", "í", "î", "ï", "ð", "ñ", "ò", "ó", "ô", "õ", "ö", "÷", "ø", "ù", "ú", "û", "ü", "ý", "þ", "ÿ"
         };
-        public static Dictionary<string, byte[]> _JapaneseSymbol = new Dictionary<string, byte[]>
+
+        public static Dictionary<string, byte[]> JapaneseSymbol = new Dictionary<string, byte[]>
         {
             #region SHIFT JIS Symbols
             {"、", new byte[] { 0x81, 0x41 } },
@@ -72,7 +80,7 @@ namespace FFXIII_ZTR_Decompressor
             {"↓", new byte[] { 0x81, 0xAB }},
             #endregion
         };
-        public static Dictionary<string, byte[]> _GameCode = new Dictionary<string, byte[]>
+        public static Dictionary<string, byte[]> GameCode = new Dictionary<string, byte[]>
         {
             #region Latin Characters (ASCII)
             {"€", new byte[] { 0x85, 0x40 }},
@@ -98,8 +106,7 @@ namespace FFXIII_ZTR_Decompressor
             {"›", new byte[] { 0x85, 0x5B }},
             {"œ", new byte[] { 0x85, 0x5C }},
             {"ž", new byte[] { 0x85, 0x5E }},
-            {"Ÿ", new byte[] { 0x85, 0x5F }},
-            {" ", new byte[] { 0x85, 0x60 }},
+            {"Ÿ", new byte[] { 0x85, 0x5F }},            
             {"¡", new byte[] { 0x85, 0x61 }},
             {"¢", new byte[] { 0x85, 0x62 }},
             {"£", new byte[] { 0x85, 0x63 }},
@@ -317,6 +324,7 @@ namespace FFXIII_ZTR_Decompressor
             {"{Icon Sphere}", new byte[] { 0xF0, 0x73 }},
             {"{Icon Neck}", new byte[] { 0xF0, 0x74 }},
             #endregion
+            #region Keys
             {"{Key Cross}", new byte[] { 0xF1, 0x40 }},
             {"{Key Circle}", new byte[] { 0xF1, 0x41 }},
             {"{Key Square}", new byte[] { 0xF1, 0x42 }},
@@ -351,6 +359,7 @@ namespace FFXIII_ZTR_Decompressor
             {"{Key LeftRightPad}", new byte[] { 0xF1, 0x5F }},
             {"{Key Arrows}", new byte[] { 0xF1, 0x60 }},
             {"{Key PadLeft}", new byte[] { 0xF1, 0x61 }},
+#endregion
 
             {"{End}", new byte[] { 0x0 }},
             {"{Escape}", new byte[] { 0x1 }},
@@ -358,8 +367,9 @@ namespace FFXIII_ZTR_Decompressor
             {"{Many}", new byte[] { 0x3 }},
             {"{Article}", new byte[] { 0x4 }},
             {"{ArticleMany}", new byte[] { 0x5 }},
-            {"{Text NewLine}", new byte[] { 0x40, 0x72 }},
-            {"{Text NewPage}", new byte[] { 0x40, 0x70 }}
+            {"{Text Tab}", new byte[] { 0x85, 0x60 }}, //Unicode Character 'NO-BREAK SPACE' (U+00A0) Used on resident/system.
+            {"{TextNewLine}", new byte[] { 0x40, 0x72 }},
+            {"{TextNewPage}", new byte[] { 0x40, 0x70 }}
         };
     }
 }

--- a/FFXIII-ZTR-Decompressor/Program.cs
+++ b/FFXIII-ZTR-Decompressor/Program.cs
@@ -17,24 +17,25 @@ namespace FFXIII_ZTR_Decompressor
                 {
                     string fileName = Path.GetFileNameWithoutExtension(file);
                     string ext = Path.GetExtension(file).ToLower();
-                    if (ext == ".txt")
+                    string name = fileName.Split((char)46).First();
+                    string lang = name.Substring(name.Length - 3);
+                    if (!GameEncoding.EncodingCode.TryGetValue(lang, out int encodingCode)) encodingCode = 65001;
+
+                    switch (ext)
                     {
-                        string name = fileName.Split((char)46).First();
-                        string lang = name.Substring(name.Length - 3);
-                        int encodingCode;
-                        if (!GameEncoding._EncodingCode.TryGetValue(lang, out encodingCode)) encodingCode = 65001;
-                        string ztr = Path.Combine(Path.GetDirectoryName(file), $"{fileName}.ztr");
-                        byte[] result = ZTR.Compressor(ztr, file, encodingCode);
-                        File.WriteAllBytes($"{file}.ztr", result);
-                    }
-                    else if (ext == ".ztr")
-                    {
-                        string name = fileName.Split((char)46).First();
-                        string lang = name.Substring(name.Length - 3);
-                        int encodingCode;
-                        if (!GameEncoding._EncodingCode.TryGetValue(lang, out encodingCode)) encodingCode = 65001;
-                        string[] result = ZTR.Decompressor(file, encodingCode);
-                        File.WriteAllLines(Path.Combine(Path.GetDirectoryName(file), $"{fileName}.txt"), result);
+                        case ".txt":
+                        {
+                            string ztr = Path.Combine(Path.GetDirectoryName(file), $"{fileName}.ztr");
+                            byte[] result = ZTR.Compressor(ztr, file, encodingCode);
+                            File.WriteAllBytes($"{file}.ztr", result);
+                            break;
+                        }
+                        case ".ztr":
+                        {
+                            string[] result = ZTR.Decompressor(file, encodingCode);
+                            File.WriteAllLines(Path.Combine(Path.GetDirectoryName(file), $"{fileName}.txt"), result);
+                            break;
+                        }
                     }
                 }
             }

--- a/FFXIII-ZTR-Decompressor/ZTR.cs
+++ b/FFXIII-ZTR-Decompressor/ZTR.cs
@@ -156,7 +156,14 @@ namespace FFXIII_ZTR_Decompressor
                 }
                 Encoding encoding = Encoding.GetEncoding(encodingCode);
                 result[i] = encoding.GetString(textBytes.ToArray());
-                //Console.WriteLine(result[i]);
+                //if (result[i].Contains("Quit"))
+                //{
+                //    foreach (var S in textBytes.ToArray())
+                //    {
+                //        Console.Write($" {S:X} ");
+                //    }
+                //    Console.WriteLine(result[i]);
+                //}
             }
             return result.ToArray();
         }

--- a/FFXIII-ZTR-Decompressor/ZTR.cs
+++ b/FFXIII-ZTR-Decompressor/ZTR.cs
@@ -37,12 +37,14 @@ namespace FFXIII_ZTR_Decompressor
         private static Header ReadHeader(ref BeBinaryReader reader)
         {
             reader.BaseStream.Seek(0, SeekOrigin.Begin);
-            Header header = new Header();
-            header.Magic = reader.ReadInt32();
-            header.Version = reader.ReadInt32();
-            header.TextCount = reader.ReadInt32();
-            header.IDsDecompressedSize = reader.ReadInt32();
-            header.TextBlocksCount = reader.ReadInt32();
+            Header header = new Header
+            {
+                Magic = reader.ReadInt32(),
+                Version = reader.ReadInt32(),
+                TextCount = reader.ReadInt32(),
+                IDsDecompressedSize = reader.ReadInt32(),
+                TextBlocksCount = reader.ReadInt32()
+            };
             header.TextBlocksPointer = new int[header.TextBlocksCount];
             for (int i = 0; i < header.TextBlocksCount; i++)
             {
@@ -56,11 +58,13 @@ namespace FFXIII_ZTR_Decompressor
             TextInfo[] textInfos = new TextInfo[header.TextCount];
             for (int i = 0; i < textInfos.Length; i++)
             {
-                textInfos[i] = new TextInfo();
-                textInfos[i].Block = reader.ReadByte();
-                textInfos[i].BlockOffset = reader.ReadByte();
-                textInfos[i].CompressedPointer = reader.ReadUInt16();
-                textInfos[i].Index = i;
+                textInfos[i] = new TextInfo
+                {
+                    Block = reader.ReadByte(),
+                    BlockOffset = reader.ReadByte(),
+                    CompressedPointer = reader.ReadUInt16(),
+                    Index = i
+                };
             }
             return textInfos;
         }
@@ -75,11 +79,9 @@ namespace FFXIII_ZTR_Decompressor
                 List<byte> value = new List<byte>();
                 byte valueFirst = reader.ReadByte();
                 byte valueLast = reader.ReadByte();
-                byte[] valueFirstKey;
-                byte[] valueLastKey;
-                if (dict.Dict.TryGetValue(valueFirst, out valueFirstKey)) value.AddRange(valueFirstKey);
+                if (dict.Dict.TryGetValue(valueFirst, out byte[] valueFirstKey)) value.AddRange(valueFirstKey);
                 else value.Add(valueFirst);
-                if (dict.Dict.TryGetValue(valueLast, out valueLastKey)) value.AddRange(valueLastKey);
+                if (dict.Dict.TryGetValue(valueLast, out byte[] valueLastKey)) value.AddRange(valueLastKey);
                 else value.Add(valueLast);
                 dict.Dict.Add(key, value.ToArray());
             }
@@ -96,8 +98,7 @@ namespace FFXIII_ZTR_Decompressor
                 while (totalBytes.Count < header.IDsDecompressedSize && blockLen < 4096)
                 {
                     byte entry = reader.ReadByte();
-                    byte[] compressed;
-                    if (idsDict.Dict.TryGetValue(entry, out compressed))
+                    if (idsDict.Dict.TryGetValue(entry, out byte[] compressed))
                     {
                         foreach (byte b in compressed) totalBytes.Add(b);
                         blockLen += compressed.Length;
@@ -124,16 +125,14 @@ namespace FFXIII_ZTR_Decompressor
                 while (pointer < endBlockPointer)
                 {
                     byte entry = reader.ReadByte();
-                    byte[] compressed;
-                    if (textDict.Dict.TryGetValue(entry, out compressed)) totalBytes.AddRange(compressed);
+                    if (textDict.Dict.TryGetValue(entry, out byte[] compressed)) totalBytes.AddRange(compressed);
                     else totalBytes.Add(entry);
                     pointer++;
                 }
             }
             string[] result = new string[header.TextCount];
-            Dictionary<string, byte[]> gameCode = new Dictionary<string, byte[]>();
-            foreach (KeyValuePair<string, byte[]> entry in GameEncoding._GameCode) gameCode.Add(entry.Key, entry.Value);
-            if (encodingCode == 65001) foreach (KeyValuePair<string, byte[]> entry in GameEncoding._JapaneseSymbol) gameCode.Add(entry.Key, entry.Value);
+            Dictionary<string, byte[]> gameCode = GameEncoding.GameCode.ToDictionary(entry => entry.Key, entry => entry.Value);
+            if (encodingCode == 65001) foreach (KeyValuePair<string, byte[]> entry in GameEncoding.JapaneseSymbol) gameCode.Add(entry.Key, entry.Value);
             int index = 0;
             for (int i = 0; i < result.Length; i++)
             {
@@ -145,12 +144,15 @@ namespace FFXIII_ZTR_Decompressor
                         index += 2;
                         break;
                     }
-                    else textBytes.Add(totalBytes[index++]);
-                } 
-                foreach (KeyValuePair<string, byte[]> entry in gameCode)
+
+                    textBytes.Add(totalBytes[index++]);
+                }
+                foreach (byte[] temp in gameCode.Select(entry => ByteArrayHandler.ReplaceBytes(textBytes.ToArray(),
+                                 entry.Value,
+                                 Encoding.UTF8.GetBytes(entry.Key)))
+                             .Where(temp => temp != null))
                 {
-                    byte[] temp = ByteArrayHandler.ReplaceBytes(textBytes.ToArray(), entry.Value, Encoding.UTF8.GetBytes(entry.Key));
-                    if (temp != null) textBytes = temp.ToList();
+                    textBytes = temp.ToList();
                 }
                 Encoding encoding = Encoding.GetEncoding(encodingCode);
                 result[i] = encoding.GetString(textBytes.ToArray());
@@ -197,7 +199,8 @@ namespace FFXIII_ZTR_Decompressor
                                 {
                                     value.Add(line);
                                 }
-                            } catch { }
+                            }
+                            catch { }
                             input.Add(key, string.Join("\n", value.ToArray()));
                         }
                         else line = sr.ReadLine();
@@ -216,8 +219,8 @@ namespace FFXIII_ZTR_Decompressor
                     string[] idsDecompressed = DecompressIDs(ref reader, header);
                     long textCompressedPointer = reader.BaseStream.Position;
                     Dictionary<string, byte[]> gameCode = new Dictionary<string, byte[]>();
-                    foreach (KeyValuePair<string, byte[]> entry in GameEncoding._GameCode) gameCode.Add(entry.Key, entry.Value);
-                    if (encodingCode == 65001) foreach (KeyValuePair<string, byte[]> entry in GameEncoding._JapaneseSymbol) gameCode.Add(entry.Key, entry.Value);
+                    foreach (KeyValuePair<string, byte[]> entry in GameEncoding.GameCode) gameCode.Add(entry.Key, entry.Value);
+                    if (encodingCode == 65001) foreach (KeyValuePair<string, byte[]> entry in GameEncoding.JapaneseSymbol) gameCode.Add(entry.Key, entry.Value);
                     int uncompressedSize = 0;
                     for (int i = 0; i < idsDecompressed.Length; i++)
                     {
@@ -228,7 +231,12 @@ namespace FFXIII_ZTR_Decompressor
                             foreach (KeyValuePair<string, byte[]> entry in gameCode)
                             {
                                 byte[] temp = ByteArrayHandler.ReplaceBytes(bs, Encoding.UTF8.GetBytes(entry.Key), entry.Value);
-                                if (temp != null) bs = temp;
+
+                                if (temp != null)
+                                {
+                                    bs = temp;
+                                    var infoo = Encoding.UTF8.GetString(temp);
+                                }
                             }
                             byte[] textBytes = new byte[bs.Length + 2];
                             bs.CopyTo(textBytes, 0);
@@ -254,7 +262,7 @@ namespace FFXIII_ZTR_Decompressor
 
                     int textIndex = 0;
                     int blockPointer = 0;
-                    
+
                     while (blockCount <= 0xFF && textIndex < textInfos.Length - 1)
                     {
                         List<byte> uncompressedBlock = new List<byte>();


### PR DESCRIPTION
My mistake. Sorry.

{" ", new byte[] { 0x85, 0x60 }}, cause this problem with Tags on compressor.

byte[] { 0x85, 0x60 }}, is Unicode Character 'NO-BREAK SPACE' (U+00A0) Used on resident/system.
I don't know a better way to represent these characters in the tag.

{"{Text Tab}", new byte[] { 0x85, 0x60 }}, //Unicode Character 'NO-BREAK SPACE' (U+00A0) Used on resident/system.